### PR TITLE
Disable all check of other domains

### DIFF
--- a/confirm-address/chrome/content/confirm-address-dialog.js
+++ b/confirm-address/chrome/content/confirm-address-dialog.js
@@ -24,12 +24,6 @@ caDialog.startup = function () {
 	yourDomainsHeader.onclick = function(e) {
 		caDialog.switchInternalCheckBox(internalList);
 	};
-
-	//他ドメインあて先リストヘッダ
-	var otherDomainsHeader = document.getElementById("otherDomains_allcheck");
-	otherDomainsHeader.onclick = function(e) {
-		caDialog.switchInternalCheckBox(externalList);
-	};
 };
 
 caDialog.createListItem = function (item) {
@@ -86,7 +80,6 @@ caDialog.checkAllChecked = function () {
 				externalComplete = false;
 			}
 		}
-		otherdomains.getElementsByClassName("all_check")[0].checked = externalComplete;
 	}
 
 	//送信ボタンのdisable切り替え

--- a/confirm-address/chrome/content/confirm-address-dialog.xul
+++ b/confirm-address/chrome/content/confirm-address-dialog.xul
@@ -32,9 +32,7 @@
 	</listbox>
 	<listbox id="otherDomains" rows="5">
 	  <listhead>
-			<listheader id="otherDomains_allcheck" tooltiptext="&confirm.dialog.otherdomain.tooltip;">
-				<checkbox class="all_check"/>
-			</listheader>
+			<listheader />
 			<listheader />
 	    <listheader id="otherDomains_header" label="&confirm.dialog.otherdomain.label;"/>
 	  </listhead>


### PR DESCRIPTION
1.2.8までは他ドメインあてはヘッダで全てにチェックをつける機能がありませんでした。
そのほうがセキュリティ上は好ましいため、戻したほうがよいのではないでしょうか。
cc @marsf