### PR TITLE
Fixed unit test script and confirm-address dialog pass thru problem #54

### DIFF
--- a/confirm-address/manifest.json
+++ b/confirm-address/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "1.3.6b1",
+  "version": "1.3.7",
   "author": "Meatian",
   "homepage_url": "__MSG_extensionHomepage_url__",
   "applications": {

--- a/confirm-address/scripts/popup.js
+++ b/confirm-address/scripts/popup.js
@@ -130,7 +130,7 @@ browser.runtime.onMessage.addListener(async (message) => {
             recipients = message.recipients;
             prefs = message.prefs;
 
-            var domainList = prefs["CA_DOMAIN_LIST"].split(",");
+            var domainList = getDomainList(prefs["CA_DOMAIN_LIST"]);
 
             var internalList = [];
             var externalList = [];
@@ -157,6 +157,15 @@ browser.runtime.onMessage.addListener(async (message) => {
             break;
     }
 });
+
+function getDomainList(domains) {
+    if (domains == null || domains.length == 0) {
+        return new Array();
+    } else {
+        var domainList = domains.split(",");
+        return domainList;
+    }
+}
 
 async function judge(addressArray, domainList, yourDomainAddress, otherDomainAddress) {
     //console.dir(recipients);

--- a/confirm-address/scripts/unittest/confirm-address-test.js
+++ b/confirm-address/scripts/unittest/confirm-address-test.js
@@ -4,11 +4,11 @@ DUMP = false;
  * ドメインリストが空なら全員部外者
  */
 function testJudge_domainListIsNull() {
-	addressList = new Array({address: "aaa@me.com"}, {address: "bbb@me.com"});
+	addressList = new Array({ address: "aaa@me.com" }, { address: "bbb@me.com" });
 	domainList = new Array();
 	insiders = new Array();
 	outsiders = new Array();
-	r = ConfirmAddress.judge(addressList, domainList, insiders, outsiders);
+	r = judge(addressList, domainList, insiders, outsiders);
 	assertEquals(0, insiders.length);
 	assertEquals(2, outsiders.length);
 }
@@ -17,11 +17,11 @@ function testJudge_domainListIsNull() {
  * 同僚だけ
  */
 function testJudge_onlyInSiders() {
-	addressList = new Array({address: "aaa@me.com"}, {address: "bbb@me.com"});
+	addressList = new Array({ address: "aaa@me.com" }, { address: "bbb@me.com" });
 	domainList = new Array("me.com");
 	insiders = new Array();
 	outsiders = new Array();
-	r = ConfirmAddress.judge(addressList, domainList, insiders, outsiders);
+	r = judge(addressList, domainList, insiders, outsiders);
 	assertEquals(2, insiders.length);
 	assertEquals(0, outsiders.length);
 }
@@ -30,11 +30,11 @@ function testJudge_onlyInSiders() {
  * 部外者だけ
  */
 function testJudge_onlyOutSiders() {
-	addressList = new Array({address: "aaa@out.com"}, {address: "bbb@out.com"});
+	addressList = new Array({ address: "aaa@out.com" }, { address: "bbb@out.com" });
 	domainList = new Array("me.com");
 	insiders = new Array();
 	outsiders = new Array();
-	r = ConfirmAddress.judge(addressList, domainList, insiders, outsiders);
+	r = judge(addressList, domainList, insiders, outsiders);
 	assertEquals(0, insiders.length);
 	assertEquals(2, outsiders.length);
 }
@@ -43,11 +43,11 @@ function testJudge_onlyOutSiders() {
  * 部外者、同僚いりまじり
  */
 function testJudge_InOutSiders() {
-	addressList = new Array({address: "zzz@me.com"}, {address: "aaa@out.com"}, {address: "bbb@out.com"}, {address: "ccc@me.com"});
+	addressList = new Array({ address: "zzz@me.com" }, { address: "aaa@out.com" }, { address: "bbb@out.com" }, { address: "ccc@me.com" });
 	domainList = new Array("me.com");
 	insiders = new Array();
 	outsiders = new Array();
-	r = ConfirmAddress.judge(addressList, domainList, insiders, outsiders);
+	r = judge(addressList, domainList, insiders, outsiders);
 	assertEquals(2, insiders.length);
 	assertEquals(2, outsiders.length);
 }
@@ -56,11 +56,11 @@ function testJudge_InOutSiders() {
  * 大文字でもOK
  */
 function testJudge_UpperCase() {
-	addressList = new Array({address: "TARO@ME.COM"});
+	addressList = new Array({ address: "TARO@ME.COM" });
 	domainList = new Array("me.com");
 	insiders = new Array();
 	outsiders = new Array();
-	r = ConfirmAddress.judge(addressList, domainList, insiders, outsiders);
+	r = judge(addressList, domainList, insiders, outsiders);
 	assertEquals(1, insiders.length);
 	assertEquals(0, outsiders.length);
 }
@@ -70,11 +70,11 @@ function testJudge_UpperCase() {
  * 場合に、ただしくそのアドレスを組織外として認識するか
  */
 function testJudge_OutSiderNameLooksLikeInSiderDomainName() {
-	addressList = new Array({address: "me.com@outsider.com"}, {address: "bbb@me.com"});
+	addressList = new Array({ address: "me.com@outsider.com" }, { address: "bbb@me.com" });
 	domainList = new Array("me.com");
 	insiders = new Array();
 	outsiders = new Array();
-	r = ConfirmAddress.judge(addressList, domainList, insiders, outsiders);
+	r = judge(addressList, domainList, insiders, outsiders);
 	assertEquals(1, insiders.length);
 	assertEquals(1, outsiders.length);
 }
@@ -82,16 +82,11 @@ function testJudge_OutSiderNameLooksLikeInSiderDomainName() {
 /*
  * ドメインリストの取得ができるか
  */
-function testGetDomainList(){
-	CA_CONST = {
-		DOMAIN_LIST : 0
-	};
-	nsPreferences = {
-		copyUnicharPref : function(arg){
-			return "gmail.com,me.com";
-		}
-	};
-	list = ConfirmAddress.getDomainList();
+function testGetDomainList() {
+	var prefs = {
+		CA_DOMAIN_LIST: "gmail.com,me.com"
+	}
+	list = prefs["CA_DOMAIN_LIST"].split(",");
 	assertEquals(2, list.length);
 }
 
@@ -99,17 +94,12 @@ function testGetDomainList(){
  * ドメインリストが空文字のときに、
  * 空の配列を取得できるか
  */
-function testGetDomainList_listInEmpty(){
-	CA_CONST = {
-		DOMAIN_LIST : 0
-	};
-	nsPreferences = {
-		copyUnicharPref : function(arg){
-			return "";
-		}
-	};
+function testGetDomainList_listInEmpty() {
+	var prefs = {
+		CA_DOMAIN_LIST: ""
+	}
 
-	list = ConfirmAddress.getDomainList();
+	list = getDomainList(prefs["CA_DOMAIN_LIST"]);
 	assertEquals(0, list.length);
 }
 
@@ -117,16 +107,11 @@ function testGetDomainList_listInEmpty(){
  * ドメインリストがnullのときに、
  * 空の配列を取得できるか
  */
-function testGetDomainList_listInNull(){
-	CA_CONST = {
-		DOMAIN_LIST : 0
-	};
-	nsPreferences = {
-		copyUnicharPref : function(arg){
-			return null;
-		}
-	};
+function testGetDomainList_listInNull() {
+	var prefs = {
+		CA_DOMAIN_LIST: null
+	}
 
-	list = ConfirmAddress.getDomainList();
+	list = getDomainList(prefs["CA_DOMAIN_LIST"]);
 	assertEquals(0, list.length);
 }

--- a/confirm-address/scripts/unittest/testRunner.html
+++ b/confirm-address/scripts/unittest/testRunner.html
@@ -1,64 +1,60 @@
 <html>
 
 <head>
-	<script type="text/javascript" src="../confirm-address.js"></script>
+	<script type="text/javascript" src="../popup.js"></script>
 	<script type="text/javascript" src="confirm-address-test.js"></script>
-<!--
-	<script type="text/javascript" src="../countdown.js"></script>
-	<script type="text/javascript" src="countdown-test.js"></script>
--->
 	<!-- Tests start -->
 	<script type="text/javascript">
-    function TestRunner() {
+		function TestRunner() {
 			this.pass = 0;
 			this.success = 0;
 			this.fail = 0;
-    }
+		}
 
-    TestRunner.prototype.execute = function(){
-    };
-
-		TestRunner.prototype.assertEquals = function(exp, act){
-			if(exp == act){
-				this.pass++;
-			}else{
-				throw "FAIL exp="+exp+", but act="+act;
-			}	
+		TestRunner.prototype.execute = function () {
 		};
-    var runner = new TestRunner();
 
-		function assertEquals(exp, act){
+		TestRunner.prototype.assertEquals = function (exp, act) {
+			if (exp == act) {
+				this.pass++;
+			} else {
+				throw "FAIL exp=" + exp + ", but act=" + act;
+			}
+		};
+		var runner = new TestRunner();
+
+		function assertEquals(exp, act) {
 			runner.assertEquals(exp, act);
 		}
-		
-		function dump(obj){}
-	
-		function run() {	
+
+		function dump(obj) { }
+
+		function run() {
 			var successList = new Array();
 			var failList = new Array();
 
-			for(var m in this){
-				if(m.indexOf("test") != -1){
-					try{
+			for (var m in this) {
+				if (m.indexOf("test") != -1) {
+					try {
 						this[m]();
 						successList.push(m);
-					}catch(e){
+					} catch (e) {
 						failList.push(m);
 					}
 				}
 			}
 			var result = document.getElementById("result");
-			successList.forEach(function(elm,idx,ary){
-				var div = document.createXULElement("div");
+			successList.forEach(function (elm, idx, ary) {
+				var div = document.createElement("div");
 				div.innerHTML = "OK .... " + ary[idx];
 				div.setAttribute('style', 'color: green;');
-				result.appendChild(div);	
+				result.appendChild(div);
 			});
-			failList.forEach(function(elm,idx,ary){
-				var div = document.createXULElement("div");
+			failList.forEach(function (elm, idx, ary) {
+				var div = document.createElement("div");
 				div.innerHTML = "FAIL .. " + ary[idx];
 				div.setAttribute('style', 'color: red;');
-				result.appendChild(div);	
+				result.appendChild(div);
 			});
 		}
 	</script>


### PR DESCRIPTION
* Unit test case script is ported to MailExtensions API and Chrome Browser.

* When domain list is empty and "Not Display" option enabled, confirm-address dialog passes thru problem is fixed.