### PR TITLE
Fix install on 78.7.1

### DIFF
--- a/confirm-address/manifest.json
+++ b/confirm-address/manifest.json
@@ -8,7 +8,7 @@
   "applications": {
     "gecko": {
       "id": "confirm-address@kenmaz.net",
-      "strict_min_version": "78.*"
+      "strict_min_version": "78.0"
     }
   },
   "icons": {


### PR DESCRIPTION
The Thunderbird in Ubuntu 20.04 refuses to install 1.3.7 with the
message

  Invalid XPI: Error: The use of '*' in strict_min_version is
  invalid(resource://gre/modules/addons/XPIInstall.jsm:486:11) JS Stack
  trace: loadManifestFromWebManifest@XPIInstall.jsm:486:11

Signed-off-by: Douglas Bagnall <douglas.bagnall@catalyst.net.nz>