### PR TITLE
Countdown in a pop-up window(ポップアップウインドウでのカウントダウン)

### DIFF
--- a/confirm-address/_locales/de/messages.json
+++ b/confirm-address/_locales/de/messages.json
@@ -43,8 +43,11 @@
     "caDialogAcceptbtn": {
         "message": "Senden"
     },
+    "caCountdownSubject": {
+        "message": "Subject:"
+    },
     "caCountdownTitle": {
-        "message": "Countdown"
+        "message": "Confirm-Address: Countdown"
     },
     "caCountdownMsg1": {
         "message": "Countdown..."
@@ -57,6 +60,9 @@
     },
     "caDialogCancelbtn": {
         "message": "Cancel"
+    },
+    "caCountdownNone": {
+       "message": "There is no mail to countdown."
     },
     //"setting.html": "*** L10n message ***",
     "caSettingTitle": {

--- a/confirm-address/_locales/en/messages.json
+++ b/confirm-address/_locales/en/messages.json
@@ -49,8 +49,11 @@
     "caDialogCancelbtn": {
         "message": "Cancel"
     },
+    "caCountdownSubject": {
+        "message": "Subject:"
+    },
     "caCountdownTitle": {
-        "message": "Countdown"
+        "message": "Confirm-Address: Countdown"
     },
     "caCountdownMsg1": {
         "message": "Countdown..."
@@ -60,6 +63,9 @@
     },
     "caCountdownSkip": {
         "message": "Send"
+    },
+    "caCountdownNone": {
+       "message": "There is no mail to countdown."
     },
     //"setting.html": "*** L10n message ***",
     "caSettingTitle": {

--- a/confirm-address/_locales/fr/messages.json
+++ b/confirm-address/_locales/fr/messages.json
@@ -49,8 +49,11 @@
     "caDialogCancelbtn": {
         "message": "Annuler"
     },
+    "caCountdownSubject": {
+        "message": "Subject:"
+    },    
     "caCountdownTitle": {
-        "message": "Compte à rebours"
+        "message": "Confirm-Address: Compte à rebours"
     },
     "caCountdownMsg1": {
         "message": "Compte à rebours..."
@@ -60,6 +63,9 @@
     },
     "caCountdownSkip": {
         "message": "Envoyer"
+    },
+    "caCountdownNone": {
+       "message": "Il n'y a pas de courrier à décompter."
     },
     //"setting.html": "*** L10n message ***",
     "caSettingTitle": {

--- a/confirm-address/_locales/ja/messages.json
+++ b/confirm-address/_locales/ja/messages.json
@@ -49,6 +49,9 @@
     "caDialogCancelbtn": {
         "message": "キャンセル"
     },
+    "caCountdownSubject": {
+        "message": "件名:"
+    },
     "caCountdownTitle": {
         "message": "カウントダウン"
     },
@@ -60,6 +63,9 @@
     },
     "caCountdownSkip": {
         "message": "送信"
+    },
+    "caCountdownNone": {
+       "message": "カウントダウン対象のメールはありません"
     },
     //"setting.html": "*** L10n message ***",
     "caSettingTitle": {

--- a/confirm-address/_locales/pt-BR/messages.json
+++ b/confirm-address/_locales/pt-BR/messages.json
@@ -49,8 +49,11 @@
     "caDialogCancelbtn": {
         "message": "Cancel"
     },
+    "caCountdownSubject": {
+        "message": "Subject:"
+    },    
     "caCountdownTitle": {
-        "message": "Contagem Regressiva"
+        "message": "Confirm-Address: Contagem Regressiva"
     },
     "caCountdownMsg1": {
         "message": "Contagem Regressiva..."
@@ -60,6 +63,9 @@
     },
     "caCountdownSkip": {
         "message": "Enviar"
+    },
+    "caCountdownNone": {
+       "message": "Não há correio a ser contado."
     },
     //"setting.html": "*** L10n message ***",
     "caSettingTitle": {

--- a/confirm-address/html/common.css
+++ b/confirm-address/html/common.css
@@ -26,7 +26,7 @@
   }
   .box_scrollbar {
     overflow: auto;
-    width: 300px;
+    width: 500px;
     height: 80px;
     padding: 5px;
     border: 1px solid #fff;
@@ -38,7 +38,7 @@
   .box_title {
     border: 1px solid #fff;
     padding: 5px;
-    width: 300px;
+    width: 500px;
     font-weight: bold;
     font-size: 14px;
     background-color: #777;
@@ -67,7 +67,7 @@
   }
   .box_scrollbar {
     overflow: auto;
-    width: 300px;
+    width: 500px;
     height: 80px;
     padding: 5px;
     border: 1px solid #000;
@@ -79,7 +79,7 @@
   .box_title {
     border: 1px solid #000;
     padding: 5px;
-    width: 300px;
+    width: 500px;
     font-weight: bold;
     font-size: 14px;
     background-color: #000;

--- a/confirm-address/html/confirm-address-popup.html
+++ b/confirm-address/html/confirm-address-popup.html
@@ -55,11 +55,6 @@
             <div id="Attachments" class="box_scrollbar">
             </div>
         </div>
-        <div id="countdownArea" style="display:none;">
-            <span id="countdown1" l10n-tag="caCountdownMsg1"></span>
-            <span id="counter"></span>&nbsp;
-            <span id="countdown2" l10n-tag="caCountdownMsg2"></span>
-        </div>
         <div>
             <input type="button" name="btn_send" l10n-val-tag="caDialogAcceptbtn" disabled="true">
             &nbsp;

--- a/confirm-address/html/countdown.html
+++ b/confirm-address/html/countdown.html
@@ -11,17 +11,15 @@
     </head>
     <body>
 
-    <h1>Confirm-Address: Countdown</h1>
-    <p id="noitems" style="display:none">
-        There is no mail to countdown.
-    </p>
+    <h1 l10n-tag="caCountdownTitle"></h1>
+    <p id="noitems" style="display:none" l10n-tag="caCountdownNone"></p>
 
     <!-- Countdown Queue Item Template -->
     <template id="caCDQItem">
         <form>
         <div id="caCD">
             <div class="box_title">
-                <span>Subject: </span><span id="mailSubject"></span>
+                <span l10n-tab="caCountdownSubject"></span>&nbsp;<span id="mailSubject"></span>
             </div>
 
             <div id="countdownMessage" class="box_scrollbar">
@@ -31,7 +29,8 @@
                     <span id="countdown2" l10n-tag="caCountdownMsg2"></span>
                 </p>
                 <p>
-                    <button id="btn_send_now">Send Now</button>&nbsp;<button id="btn_abort">Abort</button>
+                    <button id="btn_send_now" l10n-val-tag="caCountdownSkip"></button>
+                    &nbsp;<button id="btn_abort" l10n-val-tag="caDialogCancelbtn"></button>
                 </p>
             </div>
         </div>

--- a/confirm-address/html/countdown.html
+++ b/confirm-address/html/countdown.html
@@ -29,8 +29,8 @@
                     <span id="countdown2" l10n-tag="caCountdownMsg2"></span>
                 </p>
                 <p>
-                    <button id="btn_send_now" l10n-val-tag="caCountdownSkip"></button>
-                    &nbsp;<button id="btn_abort" l10n-val-tag="caDialogCancelbtn"></button>
+                    <button id="btn_send_now" l10n-tag="caCountdownSkip"></button>
+                    &nbsp;<button id="btn_abort" l10n-tag="caDialogCancelbtn"></button>
                 </p>
             </div>
         </div>

--- a/confirm-address/html/countdown.html
+++ b/confirm-address/html/countdown.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <link rel="stylesheet" type="text/css" media="screen" href="common.css">
+        <title>Confirm-Address: Countdown</title>
+        <style type="text/css">
+        </style>
+        <script src="../scripts/countdown.js" defer></script>
+        <script src="../scripts/l10n.js" defer></script>
+    </head>
+    <body>
+
+    <h1>Confirm-Address: Countdown</h1>
+    <p id="noitems" style="display:none">
+        There is no mail to countdown.
+    </p>
+
+    <!-- Countdown Queue Item Template -->
+    <template id="caCDQItem">
+        <form>
+        <div id="caCD">
+            <div class="box_title">
+                <span>Subject: </span><span id="mailSubject"></span>
+            </div>
+
+            <div id="countdownMessage" class="box_scrollbar">
+                <p>
+                    <span id="countdown1" l10n-tag="caCountdownMsg1"></span>
+                    <span id="counter"></span>&nbsp;
+                    <span id="countdown2" l10n-tag="caCountdownMsg2"></span>
+                </p>
+                <p>
+                    <button id="btn_send_now">Send Now</button>&nbsp;<button id="btn_abort">Abort</button>
+                </p>
+            </div>
+        </div>
+        </form>
+    </template>
+    
+    <!-- Actual countdown queue item places here -->
+    <div id="caCountdownQueue">
+
+    </div>
+    </body>
+</html>

--- a/confirm-address/scripts/countdown.js
+++ b/confirm-address/scripts/countdown.js
@@ -1,0 +1,90 @@
+var prefs = null;
+var numCountdown = 0;
+
+function pushSendQueue(message){
+    //console.dir(message);
+    const template = document.getElementById("caCDQItem");
+    const content = template.content;
+    const sendQueue = document.importNode(content, true);
+
+    const tabId = message.tabId;
+    var limit = message.countdownSec;
+
+    sendQueue.getElementById("mailSubject").innerText = message.mailsubject;
+    sendQueue.getElementById("counter").innerText = limit;
+
+    // set Unique ID by tabId
+    sendQueue.getElementById("counter").id = "counter-" + tabId;
+    var send_now = sendQueue.getElementById("btn_send_now");
+    send_now.id = "btn_send_now_" + tabId;
+    var abort = sendQueue.getElementById("btn_abort");
+    abort.id = "btn_abort_" + tabId;
+    sendQueue.getElementById("caCD").id = "caCD-" + tabId;
+
+    var timer = setInterval(function(){
+            limit--;
+            if (limit < 0) {
+                clearInterval(timer);
+                sendResult(true, tabId);
+                popSendQueue(tabId);
+            } else {
+                document.getElementById("counter-"+tabId).innerText = limit;
+            }
+        },1000);
+
+    send_now.addEventListener("click", function(){
+        clearInterval(timer);
+        sendResult(true, tabId);
+        popSendQueue(tabId);
+    });
+
+    abort.addEventListener("click",function(){
+        clearInterval(timer);
+        sendResult(false, tabId);
+        popSendQueue(tabId);
+    });
+    
+    document.getElementById("caCountdownQueue").appendChild(sendQueue);
+    numCountdown++;
+    translate();
+}
+
+function popSendQueue(tabId){
+    var target = document.getElementById("caCD-"+tabId);
+    target.parentNode.removeChild(target);
+    numCountdown--;
+    if(numCountdown == 0){
+        document.getElementById("noitems").style.display = "block";
+        setTimeout(function(){
+            var winId = browser.windows.WINDOW_ID_CURRENT;
+            browser.windows.remove(winId);
+        },1000);
+    }
+}
+
+async function sendResult(confirmed, tabId) {
+    if(confirmed){
+        await browser.runtime.sendMessage({
+            message: "SEND_MAIL_NOW",
+            tabId: tabId
+        });
+    } else {
+       await browser.runtime.sendMessage({
+           message: "ABORT_SEND_MAIL",
+           tabId: tabId
+       });
+    }
+}
+
+browser.runtime.onMessage.addListener(async (message) => {
+     switch (message.message) {
+         case "START_COUNTDOWN":
+            //console.dir(message);
+            pushSendQueue(message);
+            break;
+        default:
+            break;
+    }
+});
+
+//init();


### PR DESCRIPTION
以下のレビューを元にポップアップからカウントダウン機能を切り離し、ウインドウ上に複数メールのカウントダウンが出来るように実装してみました。

https://addons.thunderbird.net/ja/thunderbird/addon/confirm-address-5582/reviews/1168681/
```
投稿者: mtany - 1月 12, 2022 · 固定リンク

以前より長く使用しております。
誤送信や添付忘れなどのメール事故防止にとても有用なアドオンですが、できれば下記点を改善して頂きたいです。

あて先アドレス確認、チェック後「送信」ボタンを押してカウントダウンが始まりますが
現状ではその状態でメール作成画面が非アクティブになるとカウントダウンが止まり、メールが送信されません。
（以前は非アクティブになってもカウントダウンは継続されい、ゼロになるとメールが送信されていました）

カウントダウンの間は他のウィンドウをクリックしたら離別作業することもできず、ずっと待っていなければならないため
必然的にカウントダウンの設定秒数が短くなってしまいます。

理想としては１分くらいの設定にしておいて、その間にメール本文等の確認をして、問題無ければそのまま他の作業に移り、時間が来たら勝手に送信されている。という以前のバージョンの動きです。

ご検討宜しくお願いいたします。
```

## Comment in English with DeepL Translation:

Based on the following review, I separated the countdown function from the popup and implemented it so that multiple emails can be counted down on the window.

https://addons.thunderbird.net/ja/thunderbird/addon/confirm-address-5582/reviews/1168681/
````
Submitted by mtany - January 12, 2022 - Fixed Link

I have been using it for a long time.
I've been using this add-on for a long time now, and it's very useful for preventing mishaps such as misdirected messages and forgotten attachments, but I'd like to see the following points improved.

The countdown starts when you click the "Send" button after checking and confirming the destination address.
However, if the compose screen becomes inactive, the countdown stops and the mail is not sent.
(Previously, the countdown continued even when the screen became inactive, and the email was sent when it reached zero.)

During the countdown, you can't click on another window and work separately, so you have to wait forever.
Inevitably, the number of seconds set for the countdown becomes shorter.

Ideally, I'd like to set the countdown time to about one minute, during which time I can check the body of the message, etc., and if there are no problems, I can move on to other tasks, and when the time comes, the message will be sent automatically. This is how the previous version worked.

Please consider this.
````
